### PR TITLE
modules/nixos/common: pull updated sysctl conf from pop-os

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -807,6 +807,23 @@
         "type": "github"
       }
     },
+    "pop-os-default-settings": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1730822893,
+        "narHash": "sha256-dcsxfLCKNozIoGIAEz/wqGLA8EbNGQANE2CiEgyG2GQ=",
+        "owner": "pop-os",
+        "repo": "default-settings",
+        "rev": "7adda3868b7d95461f9e39b28c0166d95ff88e66",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pop-os",
+        "ref": "master_noble",
+        "repo": "default-settings",
+        "type": "github"
+      }
+    },
     "rocksdb": {
       "flake": false,
       "locked": {
@@ -837,6 +854,7 @@
         "nix-index-database": "nix-index-database",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_2",
+        "pop-os-default-settings": "pop-os-default-settings",
         "schizofox": "schizofox",
         "srvos": "srvos",
         "tf": "tf",

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,8 @@
     nix-index-database.url = "github:nix-community/nix-index-database/main";
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    pop-os-default-settings.url = "github:pop-os/default-settings/master_noble";
+    pop-os-default-settings.flake = false;
     schizofox.inputs.nixpkgs.follows = "nixpkgs";
     schizofox.url = "github:schizofox/schizofox/main";
     srvos.inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/nixos/common/memory.nix
+++ b/modules/nixos/common/memory.nix
@@ -7,4 +7,8 @@
 
   environment.etc."sysctl.d/10-pop-default-settings.conf".source =
     inputs.pop-os-default-settings + /etc/sysctl.d/10-pop-default-settings.conf;
+
+  boot.kernel.sysctl = {
+    "vm.swappiness" = 180;
+  };
 }

--- a/modules/nixos/common/memory.nix
+++ b/modules/nixos/common/memory.nix
@@ -1,17 +1,10 @@
-_: {
-  # https://github.com/pop-os/default-settings/blob/041cd94158142d6a34d2e684c847ac239a5ba086/etc/sysctl.d/10-pop-default-settings.conf
+{ inputs, ... }:
+{
   zramSwap = {
     enable = true;
     memoryPercent = 150;
   };
 
-  boot.kernel.sysctl = {
-    "vm.dirty_background_bytes" = 134217728;
-    "vm.dirty_bytes" = 268435456;
-    "vm.max_map_count" = 2147483642;
-    "vm.page-cluster" = 0;
-    "vm.swappiness" = 180;
-    "vm.watermark_boost_factor" = 0;
-    "vm.watermark_scale_factor" = 125;
-  };
+  environment.etc."sysctl.d/10-pop-default-settings.conf".source =
+    inputs.pop-os-default-settings + /etc/sysctl.d/10-pop-default-settings.conf;
 }

--- a/modules/nixos/common/memory.nix
+++ b/modules/nixos/common/memory.nix
@@ -9,6 +9,7 @@
     inputs.pop-os-default-settings + /etc/sysctl.d/10-pop-default-settings.conf;
 
   boot.kernel.sysctl = {
+    "vm.page-cluster" = 0;
     "vm.swappiness" = 180;
   };
 }


### PR DESCRIPTION
this also introduces `fs.inotify.max_user_instances = 1024`, from https://github.com/pop-os/default-settings/commit/821dd07407d4535fcfd870877534e69972a0353b

"tested" via `nix build .#nixosConfigurations.work-vm.config.system.build.toplevel`